### PR TITLE
Update image to RHEL 10.2 (rhel-10-2-eus-06-08-26)

### DIFF
--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -1,7 +1,7 @@
 ---
 virtualmachines:
   - name: "rhel"
-    image: "rhel-10-0-07-09-25-3"
+    image: "rhel-10-2-eus-06-08-26"
     bootloader: efi
     memory: "4G"
     cores: 1

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -6,6 +6,7 @@ virtualmachines:
     memory: "4G"
     cores: 1
     image_size: "40G"
+    register_satellite: false
     tags:
       - key: "AnsibleGroup"
         value: "bastions"

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -3,3 +3,4 @@
 # Unregister and register the VM
 subscription-manager clean
 subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
+

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -1,1 +1,5 @@
 #!/bin/bash
+
+# Unregister and register the VM
+subscription-manager clean
+subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force


### PR DESCRIPTION
## Summary
- Updated `instances.yaml` image to `rhel-10-2-eus-06-08-26`
- Disabled satellite registration (`register_satellite: false`)
- Commented out packages block
- Added subscription-manager clean & re-register to `setup-rhel.sh`
- Part of RHEL 10.2 lab migration

## Lab
Intro to Git